### PR TITLE
docs: fix readme example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ for row in res.result_set:
 res = g.query("""MATCH (r:Rider)-[:rides]->(t:Team {name:'Ducati'})
                  RETURN count(r)""")
 
-print(row[0])
+print(res.result_set[0][0])
 # Prints: 1
 ```
 


### PR DESCRIPTION
Use the correct query result in the example code in the README.

```python
print(res.result_set[0][0])
```

instead of

```python
print(row[0])
```

