### PR TITLE
ci(workflows): pin GitHub Actions dependencies to commit SHAs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Format
       run: cargo fmt --check
     - name: Build


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to their full commit SHA for supply-chain security.

## Changes

- Pin 1 action references across 1 workflow files to commit SHAs
- Version tags preserved in comments for readability

### Changed Files
- `.github/workflows/rust.yml`

## Testing

- Workflow syntax is unchanged; only the `@ref` portion of `uses:` directives is modified
- All pinned SHAs correspond to the exact same code as the original version tags

## Memory / Performance Impact

N/A - CI configuration only.

## Related Issues

Closes #32
